### PR TITLE
Support Laravel TokenGuard. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,22 @@ Auth::user() // returns instance of Pseudo/Contracts/GuestContract instead of nu
 ```
 
 ## Configuration
-#### Update Guard Driver
+#### Update Guard Driver(s)
 `config/auth.php`
 
 ```php
 'guards' => [
+    // To use with web guard
     'web' => [
         'driver' => 'pseudo',
         'provider' => 'users',
     ],
     
-    // additional guards
+    // To use with api guard
+    'api' => [
+        'driver' => 'pseudo-token',
+        'provider' => 'users',
+    ],
 ],
 ```
 

--- a/src/Pseudo/Auth/GuardHelpers.php
+++ b/src/Pseudo/Auth/GuardHelpers.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Pseudo\Auth;
+
+use Pseudo\Contracts\GuestContract;
+use Illuminate\Auth\AuthenticationException;
+
+/**
+ * These methods are typically the same across all guards.
+ */
+trait GuardHelpers
+{
+    /**
+     * The currently authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    protected $user;
+
+    /**
+     * The user provider implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\UserProvider
+     */
+    protected $provider;
+
+    /**
+     * Determine if the current user is authenticated.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function authenticate()
+    {
+        $user = $this->user();
+
+        if (! $user instanceof GuestContract) {
+            return $user;
+        }
+
+        throw new AuthenticationException;
+    }
+
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function user()
+    {
+        $user = parent::user();
+
+        if (is_null($user)) {
+            $user = resolve(GuestContract::class);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Determine if the current user is a guest.
+     *
+     * @return bool
+     */
+    public function guest()
+    {
+        return ! $this->check();
+    }
+
+    /**
+     * Determine if the current user is authenticated.
+     *
+     * @return bool
+     */
+    public function check()
+    {
+        return ! $this->user() instanceof GuestContract;
+    }
+}

--- a/src/Pseudo/Auth/SessionGuard.php
+++ b/src/Pseudo/Auth/SessionGuard.php
@@ -2,53 +2,9 @@
 
 namespace Pseudo\Auth;
 
-use Pseudo\Contracts\GuestContract;
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\SessionGuard as LaravelSessionGuard;
 
 class SessionGuard extends LaravelSessionGuard
 {
-    /**
-     * Determine if the current user is authenticated.
-     *
-     * @return bool
-     */
-    public function check()
-    {
-        return ! $this->user() instanceof GuestContract;
-    }
-
-    /**
-     * Get the currently authenticated user.
-     *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
-     */
-    public function user()
-    {
-        $user = parent::user();
-
-        if (is_null($user)) {
-            $user = resolve(GuestContract::class);
-        }
-
-        return $user;
-    }
-
-    /**
-     * Determine if the current user is authenticated.
-     *
-     * @throws \Illuminate\Auth\AuthenticationException
-     *
-     * @return \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public function authenticate()
-    {
-        $user = $this->user();
-
-        if (! $user instanceof GuestContract) {
-            return $user;
-        }
-
-        throw new AuthenticationException;
-    }
+    use GuardHelpers;
 }

--- a/src/Pseudo/Auth/TokenGuard.php
+++ b/src/Pseudo/Auth/TokenGuard.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Pseudo\Auth;
+
+use Illuminate\Auth\TokenGuard as LaravelTokenGuard;
+
+class TokenGuard extends LaravelTokenGuard
+{
+    use GuardHelpers;
+}

--- a/src/Pseudo/Providers/PseudoServiceProvider.php
+++ b/src/Pseudo/Providers/PseudoServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Pseudo\Providers;
 
 use Pseudo\Auth\Guest;
+use Pseudo\Auth\TokenGuard;
 use Pseudo\Auth\SessionGuard;
 use Pseudo\Middleware\Authorize;
 use Pseudo\Contracts\GuestContract;
@@ -34,7 +35,20 @@ class PseudoServiceProvider extends ServiceProvider
         Route::middleware('can', Authorize::class);
     }
 
+    /**
+     * Boot Auth extend overrides.
+     */
     protected function bootAuthOverrides()
+    {
+        $this->bootAuthSessionGuardOverride();
+
+        $this->bootAuthTokenGuardOverride();
+    }
+
+    /**
+     * Boot Auth extend to override SessionGuard.
+     */
+    protected function bootAuthSessionGuardOverride()
     {
         Auth::extend('pseudo', function ($app, $name, array $config) {
             $guard = new SessionGuard($name, Auth::createUserProvider($config['provider']), $app['session.store']);
@@ -50,6 +64,23 @@ class PseudoServiceProvider extends ServiceProvider
             if (method_exists($guard, 'setRequest')) {
                 $guard->setRequest($app->refresh('request', $guard, 'setRequest'));
             }
+
+            return $guard;
+        });
+    }
+
+    /**
+     * Boot Auth extend to override TokenGuard.
+     */
+    protected function bootAuthTokenGuardOverride()
+    {
+        Auth::extend('pseudo-token', function ($app, $name, array $config) {
+            $guard = new TokenGuard(
+                Auth::createUserProvider($config['provider']),
+                $app['request']
+            );
+
+            $app->refresh('request', $guard, 'setRequest');
 
             return $guard;
         });

--- a/tests/SessionGuardTest.php
+++ b/tests/SessionGuardTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Orchestra\Testbench\TestCase;
+use Pseudo\Contracts\GuestContract;
+use Illuminate\Support\Facades\Auth;
+use Pseudo\Providers\PseudoServiceProvider;
+
+class SessionGuardTest extends TestCase
+{
+    /**
+     * Test that Laravel Auth returns instance of GuestContract.
+     */
+    public function test_guard_returns_guest()
+    {
+        $this->assertInstanceOf(GuestContract::class, Auth::guard('web')->user());
+    }
+
+    /**
+     * Test that Laravel Auth returns can check for guest.
+     */
+    public function test_guard_determines_if_guest()
+    {
+        $this->assertTrue(Auth::guard('web')->guest());
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('auth.guards.web.driver', 'pseudo');
+    }
+
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            PseudoServiceProvider::class,
+        ];
+    }
+}

--- a/tests/TokenGuardTest.php
+++ b/tests/TokenGuardTest.php
@@ -3,15 +3,24 @@
 use Orchestra\Testbench\TestCase;
 use Pseudo\Contracts\GuestContract;
 use Illuminate\Support\Facades\Auth;
+use Pseudo\Providers\PseudoServiceProvider;
 
-class GuestUserTest extends TestCase
+class TokenGuardTest extends TestCase
 {
     /**
      * Test that Laravel Auth returns instance of GuestContract.
      */
-    public function test_auth_returns_guest()
+    public function test_guard_returns_guest_object()
     {
-        $this->assertInstanceOf(GuestContract::class, Auth::user());
+        $this->assertInstanceOf(GuestContract::class, Auth::guard('api')->user());
+    }
+
+    /**
+     * Test that Laravel Auth returns can check for guest.
+     */
+    public function test_guard_determines_if_guest()
+    {
+        $this->assertTrue(Auth::guard('api')->guest());
     }
 
     /**
@@ -22,7 +31,7 @@ class GuestUserTest extends TestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('auth.guards.web.driver', 'pseudo');
+        $app['config']->set('auth.guards.api.driver', 'pseudo-token');
     }
 
     /**
@@ -34,6 +43,8 @@ class GuestUserTest extends TestCase
      */
     protected function getPackageProviders($app)
     {
-        return [\Pseudo\Providers\PseudoServiceProvider::class];
+        return [
+            PseudoServiceProvider::class,
+        ];
     }
 }


### PR DESCRIPTION
Move common methods across Guards to GuardHelper Trait.

closes #7 